### PR TITLE
Allow no classTables

### DIFF
--- a/src/compiler/cpp/output.kn
+++ b/src/compiler/cpp/output.kn
@@ -1302,7 +1302,9 @@ func write(resFiles: list<[]char>)
 		
 		var writer: file@Writer :: file@makeWriter(\option@outputFile ~ ".cpp", false)
 		do writer.writeStr("#include <cstdint>\n")
-		if(^@classTable <> 0)
+		if(^@classTable = 0)
+			do writer.writeStr("static int64_t classTable_[1];\n")
+		else
 			do writer.writeStr("static int64_t classTable_[\{^@classTable}];\n")
 		end if
 		do writer.writeStr("#include \"common.h\"\n")


### PR DESCRIPTION
classを使う必要がない場合、ダミーのclassTablesが、kuin.exeに`-x merge`をつけた場合のみ宣言されます。-x mergeがある場合とない場合で同じ挙動になる方が良いと思いました。

PS: 開発お疲れさまです Linux/macOSのkuinネイティブバイナリを手に入れることができました https://qiita.com/cielavenir/items/3618e833259d85ec410b