### PR TITLE
Added Array char16_t specialization to avoid va_arg crash

### DIFF
--- a/build/output/common.h
+++ b/build/output/common.h
@@ -62,6 +62,18 @@ template<typename T> struct Array_ : public Ref_ {
 	int64_t L;
 	T* B;
 };
+template<>
+Array_<char16_t>::Array_(int64_t n, ...) noexcept : Ref_() {
+	L = n;
+	B = new char16_t[static_cast<size_t>(n + bufLen_<char16_t>())];
+	va_list l;
+	va_start(l, n);
+	for (int64_t i = 0; i < n; i++)
+		B[i] = va_arg(l, int);
+	va_end(l);
+	if (bufLen_<char16_t>() > 0)
+		B[n] = 0;
+}
 template<typename T> struct List_ : public Ref_ {
 	List_() noexcept : Ref_(), B(), I(B.end()) {}
 	int64_t Len() noexcept { return static_cast<int64_t>(B.size()); }

--- a/src/compiler/res/sys/common.h
+++ b/src/compiler/res/sys/common.h
@@ -62,6 +62,18 @@ template<typename T> struct Array_ : public Ref_ {
 	int64_t L;
 	T* B;
 };
+template<>
+Array_<char16_t>::Array_(int64_t n, ...) noexcept : Ref_() {
+	L = n;
+	B = new char16_t[static_cast<size_t>(n + bufLen_<char16_t>())];
+	va_list l;
+	va_start(l, n);
+	for (int64_t i = 0; i < n; i++)
+		B[i] = va_arg(l, int);
+	va_end(l);
+	if (bufLen_<char16_t>() > 0)
+		B[n] = 0;
+}
 template<typename T> struct List_ : public Ref_ {
 	List_() noexcept : Ref_(), B(), I(B.end()) {}
 	int64_t Len() noexcept { return static_cast<int64_t>(B.size()); }


### PR DESCRIPTION
以下のような警告が発生し、さらにg++でコンパイルした場合はIllegal instructionが発生します

本パッチでVC++で問題が出た場合は、`#if defined(__GNUC__) || defined(__clang__)`とかで囲っていただければと思います

```
$ clang++ -std=c++11 -O2 -o kuin output/kuin_cpp.cpp
In file included from output/kuin_cpp.cpp:3:
output/common.h:72:20: warning: second argument to 'va_arg' is of promotable type 'char16_t'; this va_arg has undefined behavior because arguments will be promoted to 'int' [-Wvarargs]
                B[i] = va_arg(l, char16_t);
                                 ^~~~~~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/11.0.0/include/stdarg.h:35:50: note: expanded from macro 'va_arg'
#define va_arg(ap, type)    __builtin_va_arg(ap, type)
                                                 ^~~~
1 warning generated.
```

```
$ g++-9 -std=c++11 -O2 -o kuin output/kuin_cpp.cpp
output/common.h: In constructor 'Array_<T>::Array_(int64_t, ...) [with T = char16_t]':
output/common.h:47:21: warning: 'char16_t' is promoted to 'int' when passed through '...'
   47 |    B[i] = va_arg(l, T);
      |                     ^
output/common.h:47:21: note: (so you should pass 'int' not 'char16_t' to 'va_arg')
output/common.h:47:21: note: if this code is reached, the program will abort
$ ./kuin
Illegal instruction: 4
```
