### PR TITLE
add cpp cui@input

### DIFF
--- a/src/compiler/cpp/raw_funcs.kn
+++ b/src/compiler/cpp/raw_funcs.kn
@@ -455,6 +455,17 @@
 		do codes.add("std::u16string s_ = \{str.id}->B;\n")
 		do codes.add("const std::string& t_ = utf16ToUtf8_(s_);\n")
 		do codes.add("std::cout << t_ << std::flush;\n")
+	case "cui_input"
+		do codes.add("std::string s8;\n")
+		do codes.add("std::getline(std::cin,s8);\n")
+		do codes.add("std::u16string s16 = utf8ToUtf16_(s8);\n")
+		do codes.add("Array_<char16_t>* r = new Array_<char16_t>();\n")
+		do codes.add("r->L = static_cast<int64_t>(s16.size());\n")
+		do codes.add("r->B = new char16_t[s16.size() + 1];\n")
+		do codes.add("int64_t p = 0;\n")
+		do codes.add("for (char c : s16) r->B[p++] = c;\n")
+		do codes.add("r->B[s16.size()] = 0;\n")
+		do codes.add("return r;\n")
 	case "file_copyFile"
 		do args.head()
 		var dst: \cpp\output@CppInfo :: \cpp\output@getInfo(args.get())

--- a/src/compiler/res/sys/cui.kn
+++ b/src/compiler/res/sys/cui.kn
@@ -25,5 +25,5 @@ end func
 +func [d0002.knd, _inputStr] inputStr(): []char
 end func
 
-+func [d0002.knd, _input] input(): []char
++func [__raw, cui_input] input(): []char
 end func


### PR DESCRIPTION
この辺は力技なんですね。。
とりあえず、デリミタや実行時エラーを考慮しなくて良いcui@inputだけ

例えばinputIntだと

```
int64_t n;
if(!(cin>>n))throw \{excpt@invalidDataFmt $ bit32}U;}
return n;
```

とかがありえると思いますが、`cui@delimiter`を無視していますからね。。