### PR TITLE
[WIP] エディタ上の補完の別スレッド化

### DIFF
--- a/build/build_editor.bat
+++ b/build/build_editor.bat
@@ -2,7 +2,7 @@
 setlocal
 pushd "%~dp0"
 
-.\deploy_exe\kuincl.exe -i "%~dp0../src/kuin_editor/kuin_editor.kn" -o "%~dp0deploy_exe/kuin" -s "%~dp0deploy_exe/sys/" -e exe -r -x wnd
+.\deploy_exe\kuincl.exe -i "%~dp0../src/kuin_editor/kuin_editor.kn" -o "%~dp0deploy_exe/kuin" -s "%~dp0deploy_exe/sys/" -e exe -r
 copy /Y ".\output\x64\Release\kuin_dll\kuin_dll.dll" "%~dp0deploy_exe\data\d0917.knd"
 pause
 

--- a/build/output/kuin_cpp.vcxproj
+++ b/build/output/kuin_cpp.vcxproj
@@ -79,6 +79,8 @@
       <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DebugInformationFormat>None</DebugInformationFormat>
+      <ExceptionHandling>false</ExceptionHandling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/build/output/kuin_dll.vcxproj
+++ b/build/output/kuin_dll.vcxproj
@@ -83,6 +83,8 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <DebugInformationFormat>None</DebugInformationFormat>
+      <ExceptionHandling>false</ExceptionHandling>
+      <BufferSecurityCheck>false</BufferSecurityCheck>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/kuin_editor/dll.kn
+++ b/src/kuin_editor/dll.kn
@@ -10,7 +10,7 @@ end func
 +func[d0917.knd, Interpret1]interpret1(src: kuin@Class, line: int, me_: kuin@Class, replaceFunc: func<(\doc_src@DocSrc, int, []char)>, cursorX: int, cursorY: int, newCursorX: &int, oldLine: int, newLine: int)
 end func
 
-+func[d0917.knd, Interpret2]interpret2(option: [][]char, funcGetSrc: func<([]char): [][]char>, funcLog: func<([][]char, int, int)>): bool
++func[d0917.knd, Interpret2]interpret2(option: [][]char, funcGetSrc: func<([]char): [][]char>, funcLog: func<([][]char, int, int)>)
 end func
 
 +func[d0917.knd, Version]version(major: &int, minor: &int, micro: &int)
@@ -29,4 +29,13 @@ end func
 end func
 
 +func[d0917.knd, SetBreakPoints]setBreakPoints(breakPoints: []\src@Pos)
+end func
+
++func[d0917.knd, LockThread]lockThread()
+end func
+
++func[d0917.knd, Interpret2Running]interpret2Running(): bool
+end func
+
++func[d0917.knd, WaitEndOfInterpret2]waitEndOfInterpret2()
 end func

--- a/src/kuin_editor/form.kn
+++ b/src/kuin_editor/form.kn
@@ -898,6 +898,9 @@ func btnCompileOnPush(wnd: wnd@WndBase)
 	end try
 	do \src@docs.forEach(@fixAll, null)
 	do @updateState()
+	if(\dll@interpret2Running())
+		do \dll@waitEndOfInterpret2()
+	end if
 	do \dll@resetMemAllocator()
 	do @editLog.setText("")
 	var cmd: []char :: out
@@ -1054,6 +1057,9 @@ func btnRlsOnPush(wnd: wnd@WndBase)
 	end try
 	do \src@docs.forEach(@fixAll, null)
 	do @updateState()
+	if(\dll@interpret2Running())
+		do \dll@waitEndOfInterpret2()
+	end if
 	do \dll@resetMemAllocator()
 	do @editLog.setText("")
 	try
@@ -1265,7 +1271,7 @@ end func
 		do @drawEditor.paint()
 		do @redrawingRequired :: false
 	end if
-	if(@interpret2Required)
+	if(@interpret2Required & !\dll@interpret2Running())
 		do \src@resetErrList()
 		do \dll@resetMemAllocator()
 		var option: list<[]char> :: #list<[]char>

--- a/src/kuin_editor/kuin_editor.kn
+++ b/src/kuin_editor/kuin_editor.kn
@@ -27,6 +27,7 @@ func main()
 	
 	func mainLoop()
 		while(wnd@act())
+			do \dll@lockThread()
 			do \form@updateState()
 		end while
 	end func

--- a/src/kuin_editor/src.kn
+++ b/src/kuin_editor/src.kn
@@ -34,6 +34,7 @@ end class
 end func
 
 +func fin()
+	do \dll@waitEndOfInterpret2()
 	do @clearDocs()
 end func
 
@@ -43,6 +44,7 @@ func updateMainSrcDir(dir: []char)
 end func
 
 +func newMainSrc()
+	do \dll@waitEndOfInterpret2()
 	var doc: \doc_src@DocSrc :: #\doc_src@DocSrc
 	do @curDoc :: doc
 	do @mainSrcPath :: \common@defaultDir ~ "main.kn"
@@ -68,6 +70,7 @@ end func
 		do wnd@msgBox(\form@wndMain, msg, \common@title, %err, %ok)
 		ret
 	end if
+	do \dll@waitEndOfInterpret2()
 	do @curDoc :: doc
 	do @mainSrcPath :: path
 	do @updateMainSrcDir(file@dir(path))


### PR DESCRIPTION
残り作業
- 前回解析した内容が消えている間は補完が使えないため、前回解析したものが残るようにダブルバッファリングが必要。
- 補完が1回余分に多く走っているのを修正する。
- 1回のReadLetterで、もっとたくさん読み込んでおいて、関数呼び出しの回数を減らしてみる。