### PR TITLE
cppのコンパイルエラーを修正

### DIFF
--- a/build/output/common.h
+++ b/build/output/common.h
@@ -339,7 +339,7 @@ static bool fileForEach_(const std::u16string& p, bool r, bool(*f)(type_(Array_<
 	if (p.size() > 512)
 		return false;
 #if defined(_WIN32)
-	WIN32_FIND_DATA t;
+	WIN32_FIND_DATAW t;
 	HANDLE h;
 #else
 	dirent* t;
@@ -352,7 +352,7 @@ static bool fileForEach_(const std::u16string& p, bool r, bool(*f)(type_(Array_<
 		memcpy(p3, p.c_str(), sizeof(wchar_t) * static_cast<std::size_t>(p.size()));
 		p3[p.size()] = '*';
 		p3[p.size() + 1] = 0;
-		h = FindFirstFile(p3, &t);
+		h = FindFirstFileW(p3, &t);
 		if (h == INVALID_HANDLE_VALUE)
 			return false;
 #else
@@ -419,7 +419,7 @@ static bool fileForEach_(const std::u16string& p, bool r, bool(*f)(type_(Array_<
 			}
 		}
 #if defined(_WIN32)
-		while (FindNextFile(h, &t));
+		while (FindNextFileW(h, &t));
 #endif
 	}
 #if defined(_WIN32)
@@ -436,7 +436,7 @@ static bool delDir_(const std::u16string& p) {
 	if (!fileExists_(p.c_str()))
 		return true;
 #if defined(_WIN32)
-	WIN32_FIND_DATA t;
+	WIN32_FIND_DATAW t;
 	HANDLE h;
 #else
 	dirent* t;
@@ -449,7 +449,7 @@ static bool delDir_(const std::u16string& p) {
 		memcpy(p3, p.c_str(), sizeof(wchar_t) * static_cast<std::size_t>(p.size()));
 		p3[p.size()] = '*';
 		p3[p.size() + 1] = 0;
-		h = FindFirstFile(p3, &t);
+		h = FindFirstFileW(p3, &t);
 		if (h == INVALID_HANDLE_VALUE)
 			return false;
 #else
@@ -501,7 +501,7 @@ static bool delDir_(const std::u16string& p) {
 		}
 	}
 #if defined(_WIN32)
-	while (FindNextFile(h, &t));
+	while (FindNextFileW(h, &t));
 	FindClose(h);
 #else
 	closedir(h);
@@ -521,7 +521,7 @@ static bool copyDir_(const std::u16string& d, const std::u16string& s) {
 	if (s.size() > 512)
 		return false;
 #if defined(_WIN32)
-	WIN32_FIND_DATA t;
+	WIN32_FIND_DATAW t;
 	HANDLE h;
 #else
 	dirent* t;
@@ -534,7 +534,7 @@ static bool copyDir_(const std::u16string& d, const std::u16string& s) {
 		memcpy(p3, s.c_str(), sizeof(wchar_t) * static_cast<std::size_t>(s.size()));
 		p3[s.size()] = '*';
 		p3[s.size() + 1] = 0;
-		h = FindFirstFile(p3, &t);
+		h = FindFirstFileW(p3, &t);
 		if (h == INVALID_HANDLE_VALUE)
 			return false;
 #else
@@ -601,7 +601,7 @@ static bool copyDir_(const std::u16string& d, const std::u16string& s) {
 			}
 		}
 #if defined(_WIN32)
-		while (FindNextFile(h, &t));
+		while (FindNextFileW(h, &t));
 #endif
 	}
 #if defined(_WIN32)
@@ -614,7 +614,7 @@ static bool copyDir_(const std::u16string& d, const std::u16string& s) {
 
 static bool moveDir_(const char16_t* d, const char16_t* s) {
 #if defined(_WIN32)
-	if (::MoveFileEx(reinterpret_cast<const wchar_t*>(s), reinterpret_cast<const wchar_t*>(d), MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH | MOVEFILE_REPLACE_EXISTING))
+	if (::MoveFileExW(reinterpret_cast<const wchar_t*>(s), reinterpret_cast<const wchar_t*>(d), MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH | MOVEFILE_REPLACE_EXISTING))
 		return true;
 #endif
 	std::u16string d2 = d;

--- a/build/sys/common.h
+++ b/build/sys/common.h
@@ -339,7 +339,7 @@ static bool fileForEach_(const std::u16string& p, bool r, bool(*f)(type_(Array_<
 	if (p.size() > 512)
 		return false;
 #if defined(_WIN32)
-	WIN32_FIND_DATA t;
+	WIN32_FIND_DATAW t;
 	HANDLE h;
 #else
 	dirent* t;
@@ -352,7 +352,7 @@ static bool fileForEach_(const std::u16string& p, bool r, bool(*f)(type_(Array_<
 		memcpy(p3, p.c_str(), sizeof(wchar_t) * static_cast<std::size_t>(p.size()));
 		p3[p.size()] = '*';
 		p3[p.size() + 1] = 0;
-		h = FindFirstFile(p3, &t);
+		h = FindFirstFileW(p3, &t);
 		if (h == INVALID_HANDLE_VALUE)
 			return false;
 #else
@@ -419,7 +419,7 @@ static bool fileForEach_(const std::u16string& p, bool r, bool(*f)(type_(Array_<
 			}
 		}
 #if defined(_WIN32)
-		while (FindNextFile(h, &t));
+		while (FindNextFileW(h, &t));
 #endif
 	}
 #if defined(_WIN32)
@@ -436,7 +436,7 @@ static bool delDir_(const std::u16string& p) {
 	if (!fileExists_(p.c_str()))
 		return true;
 #if defined(_WIN32)
-	WIN32_FIND_DATA t;
+	WIN32_FIND_DATAW t;
 	HANDLE h;
 #else
 	dirent* t;
@@ -449,7 +449,7 @@ static bool delDir_(const std::u16string& p) {
 		memcpy(p3, p.c_str(), sizeof(wchar_t) * static_cast<std::size_t>(p.size()));
 		p3[p.size()] = '*';
 		p3[p.size() + 1] = 0;
-		h = FindFirstFile(p3, &t);
+		h = FindFirstFileW(p3, &t);
 		if (h == INVALID_HANDLE_VALUE)
 			return false;
 #else
@@ -501,7 +501,7 @@ static bool delDir_(const std::u16string& p) {
 		}
 	}
 #if defined(_WIN32)
-	while (FindNextFile(h, &t));
+	while (FindNextFileW(h, &t));
 	FindClose(h);
 #else
 	closedir(h);
@@ -521,7 +521,7 @@ static bool copyDir_(const std::u16string& d, const std::u16string& s) {
 	if (s.size() > 512)
 		return false;
 #if defined(_WIN32)
-	WIN32_FIND_DATA t;
+	WIN32_FIND_DATAW t;
 	HANDLE h;
 #else
 	dirent* t;
@@ -534,7 +534,7 @@ static bool copyDir_(const std::u16string& d, const std::u16string& s) {
 		memcpy(p3, s.c_str(), sizeof(wchar_t) * static_cast<std::size_t>(s.size()));
 		p3[s.size()] = '*';
 		p3[s.size() + 1] = 0;
-		h = FindFirstFile(p3, &t);
+		h = FindFirstFileW(p3, &t);
 		if (h == INVALID_HANDLE_VALUE)
 			return false;
 #else
@@ -601,7 +601,7 @@ static bool copyDir_(const std::u16string& d, const std::u16string& s) {
 			}
 		}
 #if defined(_WIN32)
-		while (FindNextFile(h, &t));
+		while (FindNextFileW(h, &t));
 #endif
 	}
 #if defined(_WIN32)
@@ -614,7 +614,7 @@ static bool copyDir_(const std::u16string& d, const std::u16string& s) {
 
 static bool moveDir_(const char16_t* d, const char16_t* s) {
 #if defined(_WIN32)
-	if (::MoveFileEx(reinterpret_cast<const wchar_t*>(s), reinterpret_cast<const wchar_t*>(d), MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH | MOVEFILE_REPLACE_EXISTING))
+	if (::MoveFileExW(reinterpret_cast<const wchar_t*>(s), reinterpret_cast<const wchar_t*>(d), MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH | MOVEFILE_REPLACE_EXISTING))
 		return true;
 #endif
 	std::u16string d2 = d;

--- a/src/sys/common.h
+++ b/src/sys/common.h
@@ -339,7 +339,7 @@ static bool fileForEach_(const std::u16string& p, bool r, bool(*f)(type_(Array_<
 	if (p.size() > 512)
 		return false;
 #if defined(_WIN32)
-	WIN32_FIND_DATA t;
+	WIN32_FIND_DATAW t;
 	HANDLE h;
 #else
 	dirent* t;
@@ -352,7 +352,7 @@ static bool fileForEach_(const std::u16string& p, bool r, bool(*f)(type_(Array_<
 		memcpy(p3, p.c_str(), sizeof(wchar_t) * static_cast<std::size_t>(p.size()));
 		p3[p.size()] = '*';
 		p3[p.size() + 1] = 0;
-		h = FindFirstFile(p3, &t);
+		h = FindFirstFileW(p3, &t);
 		if (h == INVALID_HANDLE_VALUE)
 			return false;
 #else
@@ -419,7 +419,7 @@ static bool fileForEach_(const std::u16string& p, bool r, bool(*f)(type_(Array_<
 			}
 		}
 #if defined(_WIN32)
-		while (FindNextFile(h, &t));
+		while (FindNextFileW(h, &t));
 #endif
 	}
 #if defined(_WIN32)
@@ -436,7 +436,7 @@ static bool delDir_(const std::u16string& p) {
 	if (!fileExists_(p.c_str()))
 		return true;
 #if defined(_WIN32)
-	WIN32_FIND_DATA t;
+	WIN32_FIND_DATAW t;
 	HANDLE h;
 #else
 	dirent* t;
@@ -449,7 +449,7 @@ static bool delDir_(const std::u16string& p) {
 		memcpy(p3, p.c_str(), sizeof(wchar_t) * static_cast<std::size_t>(p.size()));
 		p3[p.size()] = '*';
 		p3[p.size() + 1] = 0;
-		h = FindFirstFile(p3, &t);
+		h = FindFirstFileW(p3, &t);
 		if (h == INVALID_HANDLE_VALUE)
 			return false;
 #else
@@ -501,7 +501,7 @@ static bool delDir_(const std::u16string& p) {
 		}
 	}
 #if defined(_WIN32)
-	while (FindNextFile(h, &t));
+	while (FindNextFileW(h, &t));
 	FindClose(h);
 #else
 	closedir(h);
@@ -521,7 +521,7 @@ static bool copyDir_(const std::u16string& d, const std::u16string& s) {
 	if (s.size() > 512)
 		return false;
 #if defined(_WIN32)
-	WIN32_FIND_DATA t;
+	WIN32_FIND_DATAW t;
 	HANDLE h;
 #else
 	dirent* t;
@@ -534,7 +534,7 @@ static bool copyDir_(const std::u16string& d, const std::u16string& s) {
 		memcpy(p3, s.c_str(), sizeof(wchar_t) * static_cast<std::size_t>(s.size()));
 		p3[s.size()] = '*';
 		p3[s.size() + 1] = 0;
-		h = FindFirstFile(p3, &t);
+		h = FindFirstFileW(p3, &t);
 		if (h == INVALID_HANDLE_VALUE)
 			return false;
 #else
@@ -601,7 +601,7 @@ static bool copyDir_(const std::u16string& d, const std::u16string& s) {
 			}
 		}
 #if defined(_WIN32)
-		while (FindNextFile(h, &t));
+		while (FindNextFileW(h, &t));
 #endif
 	}
 #if defined(_WIN32)
@@ -614,7 +614,7 @@ static bool copyDir_(const std::u16string& d, const std::u16string& s) {
 
 static bool moveDir_(const char16_t* d, const char16_t* s) {
 #if defined(_WIN32)
-	if (::MoveFileEx(reinterpret_cast<const wchar_t*>(s), reinterpret_cast<const wchar_t*>(d), MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH | MOVEFILE_REPLACE_EXISTING))
+	if (::MoveFileExW(reinterpret_cast<const wchar_t*>(s), reinterpret_cast<const wchar_t*>(d), MOVEFILE_COPY_ALLOWED | MOVEFILE_WRITE_THROUGH | MOVEFILE_REPLACE_EXISTING))
 		return true;
 #endif
 	std::u16string d2 = d;


### PR DESCRIPTION
生成されたcppファイルをVC++コンパイラでコンパイルした際、下記のようなエラーが出ていたのを修正しました。
`error C2664: 'HANDLE FindFirstFileA(LPCSTR,LPWIN32_FIND_DATAA)': 引数 1 を 'wchar_t [514]' から 'LPCSTR' へ変換できません。`

空のknファイル(Hello, world!を出力するプログラム)を変換してできるcppファイルで修正前後の動作確認をしました。

(VC++でのコンパイル時に、コンパイルオプションに  /DUNICODE を入れておけば、変更無しでもコンパイルできるのですが、引数が wchar_t p3[514] という具合に宣言されているので、 `FindFirstFile` ではなく `FindFirstFileW` の方が適切と考えました。)