### PR TITLE
入力処理の速度面での改善

### DIFF
--- a/src/lib/sys/cui.kn
+++ b/src/lib/sys/cui.kn
@@ -17,8 +17,7 @@ end func
 
 +func input(): []char
 #exe,cpp
-	var bufSize: int :: @bufSizeMin
-	var buf: []char :: #[bufSize]char
+	var buf: []char :: #[^buf]char
 	var ptr: int :: 0
 	while loop(true)
 		var c: char :: @inputLetter()
@@ -35,8 +34,7 @@ end func
 			break loop
 		end if
 		if(ptr = ^buf)
-			do buf :~ #[bufSize]char
-			do bufSize :* 2
+			do buf :~ #[^buf]char
 		end if
 		do buf[ptr] :: c
 		do ptr :+ 1

--- a/src/lib/sys/cui.kn
+++ b/src/lib/sys/cui.kn
@@ -1,4 +1,4 @@
-const strBufSize: int :: 1024
+const bufSizeMin: int :: 1024
 var delimiters: []char :: " ,\n"
 
 +func delimiter(delimiters_: []char)
@@ -17,7 +17,8 @@ end func
 
 +func input(): []char
 #exe,cpp
-	var buf: []char :: #[@strBufSize]char
+	var bufSize: int :: @bufSizeMin
+	var buf: []char :: #[bufSize]char
 	var ptr: int :: 0
 	while loop(true)
 		var c: char :: @inputLetter()
@@ -34,7 +35,8 @@ end func
 			break loop
 		end if
 		if(ptr = ^buf)
-			do buf :~ #[@strBufSize]char
+			do buf :~ #[bufSize]char
+			do bufSize :* 2
 		end if
 		do buf[ptr] :: c
 		do ptr :+ 1
@@ -119,7 +121,8 @@ end func
 
 +func inputStr(): []char
 #exe,cpp
-	var buf: []char :: #[@strBufSize]char
+	var bufSize: int :: @bufSizeMin
+	var buf: []char :: #[bufSize]char
 	var ptr: int :: 0
 	while loop(true)
 		var c: char :: @inputCharWithDelimiter()
@@ -136,7 +139,8 @@ end func
 			break loop
 		end if
 		if(ptr = ^buf)
-			do buf :~ #[@strBufSize]char
+			do buf :~ #[bufSize]char
+			do bufSize :* 2
 		end if
 		do buf[ptr] :: c
 		do ptr :+ 1

--- a/src/lib/sys/cui.kn
+++ b/src/lib/sys/cui.kn
@@ -121,8 +121,7 @@ end func
 
 +func inputStr(): []char
 #exe,cpp
-	var bufSize: int :: @bufSizeMin
-	var buf: []char :: #[bufSize]char
+	var buf: []char :: #[@bufSizeMin]char
 	var ptr: int :: 0
 	while loop(true)
 		var c: char :: @inputCharWithDelimiter()
@@ -139,8 +138,7 @@ end func
 			break loop
 		end if
 		if(ptr = ^buf)
-			do buf :~ #[bufSize]char
-			do bufSize :* 2
+			do buf :~ #[^buf]char
 		end if
 		do buf[ptr] :: c
 		do ptr :+ 1

--- a/src/lib/sys/cui.kn
+++ b/src/lib/sys/cui.kn
@@ -17,7 +17,7 @@ end func
 
 +func input(): []char
 #exe,cpp
-	var buf: []char :: #[^buf]char
+	var buf: []char :: #[@bufSizeMin]char
 	var ptr: int :: 0
 	while loop(true)
 		var c: char :: @inputLetter()

--- a/src/lib/sys/file.kn
+++ b/src/lib/sys/file.kn
@@ -1,5 +1,4 @@
 const bufSizeMin: int :: 1024
-var bufSize: int
 var strBuf: []char
 var eBuf: []bit8
 #web
@@ -11,8 +10,7 @@ func[d0000.knd, _fileInit]_init()
 #cpp,web
 func _init()
 #any
-	do @bufSize :: @bufSizeMin
-	do @strBuf :: #[@bufSize]char
+	do @strBuf :: #[@bufSizeMin]char
 	do @eBuf :: #[8]bit8
 #cpp
 	; TODO:
@@ -192,8 +190,7 @@ end enum
 				break loop
 			end if
 			if(ptr = ^buf)
-				do buf :~ #[@bufSize]char
-				do @bufSize :* 2
+				do buf :~ #[^buf]char
 			end if
 			do buf[ptr] :: c
 			do ptr :+ 1
@@ -219,8 +216,7 @@ end enum
 				break loop
 			end if
 			if(ptr = ^buf)
-				do buf :~ #[@bufSize]char
-				do @bufSize :* 2
+				do buf :~ #[^buf]char
 			end if
 			do buf[ptr] :: c
 			do ptr :+ 1

--- a/src/lib/sys/file.kn
+++ b/src/lib/sys/file.kn
@@ -1,4 +1,5 @@
-const strBufSize: int :: 1024
+const bufSizeMin: int :: 1024
+var bufSize: int
 var strBuf: []char
 var eBuf: []bit8
 #web
@@ -10,7 +11,8 @@ func[d0000.knd, _fileInit]_init()
 #cpp,web
 func _init()
 #any
-	do @strBuf :: #[@strBufSize]char
+	do @bufSize :: @bufSizeMin
+	do @strBuf :: #[@bufSize]char
 	do @eBuf :: #[8]bit8
 #cpp
 	; TODO:
@@ -190,7 +192,8 @@ end enum
 				break loop
 			end if
 			if(ptr = ^buf)
-				do buf :~ #[@strBufSize]char
+				do buf :~ #[@bufSize]char
+				do @bufSize :* 2
 			end if
 			do buf[ptr] :: c
 			do ptr :+ 1
@@ -216,7 +219,8 @@ end enum
 				break loop
 			end if
 			if(ptr = ^buf)
-				do buf :~ #[@strBufSize]char
+				do buf :~ #[@bufSize]char
+				do @bufSize :* 2
 			end if
 			do buf[ptr] :: c
 			do ptr :+ 1

--- a/src/sys/cpp/cui.kn
+++ b/src/sys/cpp/cui.kn
@@ -91,8 +91,7 @@ end func
 end func
 
 +func inputStr(): []char
-	var bufSize: int :: @bufSizeMin
-	var buf: []char :: #[bufSize]char
+	var buf: []char :: #[@bufSizeMin]char
 	var ptr: int :: 0
 	while loop(true)
 		var c: char :: @inputCharWithDelimiter()
@@ -109,8 +108,7 @@ end func
 			break loop
 		end if
 		if(ptr = ^buf)
-			do buf :~ #[bufSize]char
-			do bufSize :* 2
+			do buf :~ #[^buf]char
 		end if
 		do buf[ptr] :: c
 		do ptr :+ 1

--- a/src/sys/cpp/cui.kn
+++ b/src/sys/cpp/cui.kn
@@ -1,4 +1,4 @@
-const strBufSize: int :: 1024
+const bufSizeMin: int :: 1024
 var delimiters: []char :: " ,\n"
 
 +func delimiter(delimiters_: []char)
@@ -10,7 +10,8 @@ end func
 end func
 
 +func input(): []char
-	var buf: []char :: #[@strBufSize]char
+	var bufSize: int :: @bufSizeMin
+	var buf: []char :: #[bufSize]char
 	var ptr: int :: 0
 	while loop(true)
 		var c: char :: @inputLetter()
@@ -27,7 +28,8 @@ end func
 			break loop
 		end if
 		if(ptr = ^buf)
-			do buf :~ #[@strBufSize]char
+			do buf :~ #[bufSize]char
+			do bufSize :* 2
 		end if
 		do buf[ptr] :: c
 		do ptr :+ 1
@@ -89,7 +91,8 @@ end func
 end func
 
 +func inputStr(): []char
-	var buf: []char :: #[@strBufSize]char
+	var bufSize: int :: @bufSizeMin
+	var buf: []char :: #[bufSize]char
 	var ptr: int :: 0
 	while loop(true)
 		var c: char :: @inputCharWithDelimiter()
@@ -106,7 +109,8 @@ end func
 			break loop
 		end if
 		if(ptr = ^buf)
-			do buf :~ #[@strBufSize]char
+			do buf :~ #[bufSize]char
+			do bufSize :* 2
 		end if
 		do buf[ptr] :: c
 		do ptr :+ 1

--- a/src/sys/cpp/cui.kn
+++ b/src/sys/cpp/cui.kn
@@ -10,7 +10,7 @@ end func
 end func
 
 +func input(): []char
-	var buf: []char :: #[^buf]char
+	var buf: []char :: #[@bufSizeMin]char
 	var ptr: int :: 0
 	while loop(true)
 		var c: char :: @inputLetter()

--- a/src/sys/cpp/cui.kn
+++ b/src/sys/cpp/cui.kn
@@ -10,8 +10,7 @@ end func
 end func
 
 +func input(): []char
-	var bufSize: int :: @bufSizeMin
-	var buf: []char :: #[bufSize]char
+	var buf: []char :: #[^buf]char
 	var ptr: int :: 0
 	while loop(true)
 		var c: char :: @inputLetter()
@@ -28,8 +27,7 @@ end func
 			break loop
 		end if
 		if(ptr = ^buf)
-			do buf :~ #[bufSize]char
-			do bufSize :* 2
+			do buf :~ #[^buf]char
 		end if
 		do buf[ptr] :: c
 		do ptr :+ 1

--- a/src/sys/cpp/file.kn
+++ b/src/sys/cpp/file.kn
@@ -1,11 +1,9 @@
 const bufSizeMin: int :: 1024
-var bufSize: int
 var strBuf: []char
 var eBuf: []bit8
 
 func _init()
-	do @bufSize :: @bufSizeMin
-	do @strBuf :: #[@bufSize]char
+	do @strBuf :: #[@bufSizeMin]char
 	do @eBuf :: #[8]bit8
 	; TODO:
 end func
@@ -170,8 +168,7 @@ end enum
 				break loop
 			end if
 			if(ptr = ^buf)
-				do buf :~ #[@bufSize]char
-				do @bufSize :* 2
+				do buf :~ #[^buf]char
 			end if
 			do buf[ptr] :: c
 			do ptr :+ 1
@@ -197,8 +194,7 @@ end enum
 				break loop
 			end if
 			if(ptr = ^buf)
-				do buf :~ #[@bufSize]char
-				do @bufSize :* 2
+				do buf :~ #[^buf]char
 			end if
 			do buf[ptr] :: c
 			do ptr :+ 1

--- a/src/sys/cpp/file.kn
+++ b/src/sys/cpp/file.kn
@@ -1,9 +1,11 @@
-const strBufSize: int :: 1024
+const bufSizeMin: int :: 1024
+var bufSize: int
 var strBuf: []char
 var eBuf: []bit8
 
 func _init()
-	do @strBuf :: #[@strBufSize]char
+	do @bufSize :: @bufSizeMin
+	do @strBuf :: #[@bufSize]char
 	do @eBuf :: #[8]bit8
 	; TODO:
 end func
@@ -168,7 +170,8 @@ end enum
 				break loop
 			end if
 			if(ptr = ^buf)
-				do buf :~ #[@strBufSize]char
+				do buf :~ #[@bufSize]char
+				do @bufSize :* 2
 			end if
 			do buf[ptr] :: c
 			do ptr :+ 1
@@ -194,7 +197,8 @@ end enum
 				break loop
 			end if
 			if(ptr = ^buf)
-				do buf :~ #[@strBufSize]char
+				do buf :~ #[@bufSize]char
+				do @bufSize :* 2
 			end if
 			do buf[ptr] :: c
 			do ptr :+ 1

--- a/src/sys/exe/cui.kn
+++ b/src/sys/exe/cui.kn
@@ -9,8 +9,7 @@ end func
 end func
 
 +func input(): []char
-	var bufSize: int :: @bufSizeMin
-	var buf: []char :: #[bufSize]char
+	var buf: []char :: #[^buf]char
 	var ptr: int :: 0
 	while loop(true)
 		var c: char :: @inputLetter()
@@ -27,8 +26,7 @@ end func
 			break loop
 		end if
 		if(ptr = ^buf)
-			do buf :~ #[bufSize]char
-			do bufSize :* 2
+			do buf :~ #[^buf]char
 		end if
 		do buf[ptr] :: c
 		do ptr :+ 1

--- a/src/sys/exe/cui.kn
+++ b/src/sys/exe/cui.kn
@@ -1,4 +1,4 @@
-const strBufSize: int :: 1024
+const bufSizeMin: int :: 1024
 var delimiters: []char :: " ,\n"
 
 +func delimiter(delimiters_: []char)
@@ -9,7 +9,8 @@ end func
 end func
 
 +func input(): []char
-	var buf: []char :: #[@strBufSize]char
+	var bufSize: int :: @bufSizeMin
+	var buf: []char :: #[bufSize]char
 	var ptr: int :: 0
 	while loop(true)
 		var c: char :: @inputLetter()
@@ -26,7 +27,8 @@ end func
 			break loop
 		end if
 		if(ptr = ^buf)
-			do buf :~ #[@strBufSize]char
+			do buf :~ #[bufSize]char
+			do bufSize :* 2
 		end if
 		do buf[ptr] :: c
 		do ptr :+ 1
@@ -70,7 +72,8 @@ end func
 end func
 
 +func inputStr(): []char
-	var buf: []char :: #[@strBufSize]char
+	var bufSize: int :: @bufSizeMin
+	var buf: []char :: #[bufSize]char
 	var ptr: int :: 0
 	while loop(true)
 		var c: char :: @inputCharWithDelimiter()
@@ -87,7 +90,8 @@ end func
 			break loop
 		end if
 		if(ptr = ^buf)
-			do buf :~ #[@strBufSize]char
+			do buf :~ #[bufSize]char
+			do bufSize :* 2
 		end if
 		do buf[ptr] :: c
 		do ptr :+ 1

--- a/src/sys/exe/cui.kn
+++ b/src/sys/exe/cui.kn
@@ -72,8 +72,7 @@ end func
 end func
 
 +func inputStr(): []char
-	var bufSize: int :: @bufSizeMin
-	var buf: []char :: #[bufSize]char
+	var buf: []char :: #[@bufSizeMin]char
 	var ptr: int :: 0
 	while loop(true)
 		var c: char :: @inputCharWithDelimiter()
@@ -90,8 +89,7 @@ end func
 			break loop
 		end if
 		if(ptr = ^buf)
-			do buf :~ #[bufSize]char
-			do bufSize :* 2
+			do buf :~ #[^buf]char
 		end if
 		do buf[ptr] :: c
 		do ptr :+ 1

--- a/src/sys/exe/cui.kn
+++ b/src/sys/exe/cui.kn
@@ -9,7 +9,7 @@ end func
 end func
 
 +func input(): []char
-	var buf: []char :: #[^buf]char
+	var buf: []char :: #[@bufSizeMin]char
 	var ptr: int :: 0
 	while loop(true)
 		var c: char :: @inputLetter()

--- a/src/sys/exe/file.kn
+++ b/src/sys/exe/file.kn
@@ -1,11 +1,9 @@
 const bufSizeMin: int :: 1024
-var bufSize: int
 var strBuf: []char
 var eBuf: []bit8
 
 func[d0000.knd, _fileInit]_init()
-	do @bufSize :: @bufSizeMin
-	do @strBuf :: #[@bufSize]char
+	do @strBuf :: #[@bufSizeMin]char
 	do @eBuf :: #[8]bit8
 end func
 
@@ -164,8 +162,7 @@ end enum
 				break loop
 			end if
 			if(ptr = ^buf)
-				do buf :~ #[@bufSize]char
-				do @bufSize :* 2
+				do buf :~ #[^buf]char
 			end if
 			do buf[ptr] :: c
 			do ptr :+ 1
@@ -191,8 +188,7 @@ end enum
 				break loop
 			end if
 			if(ptr = ^buf)
-				do buf :~ #[@bufSize]char
-				do @bufSize :* 2
+				do buf :~ #[^buf]char
 			end if
 			do buf[ptr] :: c
 			do ptr :+ 1

--- a/src/sys/exe/file.kn
+++ b/src/sys/exe/file.kn
@@ -1,9 +1,11 @@
-const strBufSize: int :: 1024
+const bufSizeMin: int :: 1024
+var bufSize: int
 var strBuf: []char
 var eBuf: []bit8
 
 func[d0000.knd, _fileInit]_init()
-	do @strBuf :: #[@strBufSize]char
+	do @bufSize :: @bufSizeMin
+	do @strBuf :: #[@bufSize]char
 	do @eBuf :: #[8]bit8
 end func
 
@@ -162,7 +164,8 @@ end enum
 				break loop
 			end if
 			if(ptr = ^buf)
-				do buf :~ #[@strBufSize]char
+				do buf :~ #[@bufSize]char
+				do @bufSize :* 2
 			end if
 			do buf[ptr] :: c
 			do ptr :+ 1
@@ -188,7 +191,8 @@ end enum
 				break loop
 			end if
 			if(ptr = ^buf)
-				do buf :~ #[@strBufSize]char
+				do buf :~ #[@bufSize]char
+				do @bufSize :* 2
 			end if
 			do buf[ptr] :: c
 			do ptr :+ 1

--- a/src/sys/web/cui.kn
+++ b/src/sys/web/cui.kn
@@ -1,4 +1,4 @@
-const strBufSize: int :: 1024
+const bufSizeMin: int :: 1024
 var delimiters: []char :: " ,\n"
 
 +func delimiter(delimiters_: []char)

--- a/src/sys/web/file.kn
+++ b/src/sys/web/file.kn
@@ -1,12 +1,10 @@
 const bufSizeMin: int :: 1024
-var bufSize: int
 var strBuf: []char
 var eBuf: []bit8
 var curDir: []char
 
 func _init()
-	do @bufSize :: @bufSizeMin
-	do @strBuf :: #[@bufSize]char
+	do @strBuf :: #[@bufSizeMin]char
 	do @eBuf :: #[8]bit8
 	do @curDir :: "/"
 end func
@@ -166,8 +164,7 @@ end enum
 				break loop
 			end if
 			if(ptr = ^buf)
-				do buf :~ #[@bufSize]char
-				do @bufSize :* 2
+				do buf :~ #[^buf]char
 			end if
 			do buf[ptr] :: c
 			do ptr :+ 1
@@ -193,8 +190,7 @@ end enum
 				break loop
 			end if
 			if(ptr = ^buf)
-				do buf :~ #[@bufSize]char
-				do @bufSize :* 2
+				do buf :~ #[^buf]char
 			end if
 			do buf[ptr] :: c
 			do ptr :+ 1

--- a/src/sys/web/file.kn
+++ b/src/sys/web/file.kn
@@ -1,10 +1,12 @@
-const strBufSize: int :: 1024
+const bufSizeMin: int :: 1024
+var bufSize: int
 var strBuf: []char
 var eBuf: []bit8
 var curDir: []char
 
 func _init()
-	do @strBuf :: #[@strBufSize]char
+	do @bufSize :: @bufSizeMin
+	do @strBuf :: #[@bufSize]char
 	do @eBuf :: #[8]bit8
 	do @curDir :: "/"
 end func
@@ -164,7 +166,8 @@ end enum
 				break loop
 			end if
 			if(ptr = ^buf)
-				do buf :~ #[@strBufSize]char
+				do buf :~ #[@bufSize]char
+				do @bufSize :* 2
 			end if
 			do buf[ptr] :: c
 			do ptr :+ 1
@@ -190,7 +193,8 @@ end enum
 				break loop
 			end if
 			if(ptr = ^buf)
-				do buf :~ #[@strBufSize]char
+				do buf :~ #[@bufSize]char
+				do @bufSize :* 2
 			end if
 			do buf[ptr] :: c
 			do ptr :+ 1


### PR DESCRIPTION
yukicoderの「4進FizzBuzz」という問題で実行時間オーバー(TLE)するので( https://yukicoder.me/submissions/464251 )、原因を調べたところ、標準入力から200万文字受け取る段階で時間がかかりすぎていることがわかりました。
そこで、改善を行いました。

下記のようにテストを行い、処理速度の向上具合を測定しました。
文字数が多いほど差が顕著になり、16777216 bytes 読むのに 89195 msec かかっていたのが、改善版だと 1438 msec (約0.016倍)で済みます。

# `file@Reader.readLine` のテスト
## テストに使用したコード
```
const filename: []char :: "___test___.txt"
var size: []int
func main()
	do @size :: #[0]int
	if(true)
		for i(10, 24)
			do @size :~ [2 ^ i]
		end for
	else
		for i(1, 7)
			do @size :~ [10 ^ i]
		end for
	end if
	
	var writer: file@Writer :: file@makeWriter(@filename, false)
	for i(0, ^@size - 1)
		var str: []char :: "1".repeat(@size[i]) ~ "\n"
		do writer.writeStr(str)
	end for
	do writer.fin()
	
	do testReadLines()
	
	func testReadLines(): []char
		var reader: file@Reader :: file@makeReader(@filename)
		do cui@print("Test #1 to #\{^@size}\n")
		do cui@print(" #          Time [          Bytes] (         Total)\n")
		var startTime0: int :: lib@sysTime()
		for i(1, ^@size)
			var startTime: int :: lib@sysTime()
			var input: []char :: reader.readLine()
			var endTime: int :: lib@sysTime()
			var totalTime: int :: endTime - startTime0
			do cui@print("\{i.toStrFmt("2d")}\{(endTime - startTime).toStrFmt("9d")} msec [\{(^input).toStrFmt("9d")} bytes] (\{(endTime - startTime0).toStrFmt("9d")} msec)\n")
		end for
		do reader.fin()
	end func
end func
```

## 現行版の結果 (`file@Reader.readLine`)
```
> kuincl -i main.kn -o main.exe -r -q && main.exe
Test #1 to #15
 #          Time [          Bytes] (         Total)
 1        0 msec [     1024 bytes] (        0 msec)
 2        0 msec [     2048 bytes] (        2 msec)
 3        0 msec [     4096 bytes] (        3 msec)
 4        1 msec [     8192 bytes] (        5 msec)
 5        2 msec [    16384 bytes] (        9 msec)
 6        4 msec [    32768 bytes] (       13 msec)
 7        7 msec [    65536 bytes] (       21 msec)
 8       13 msec [   131072 bytes] (       34 msec)
 9       28 msec [   262144 bytes] (       63 msec)
10       82 msec [   524288 bytes] (      147 msec)
11      329 msec [  1048576 bytes] (      478 msec)
12     1232 msec [  2097152 bytes] (     1713 msec)
13     4882 msec [  4194304 bytes] (     6598 msec)
14    21236 msec [  8388608 bytes] (    27837 msec)
15    89195 msec [ 16777216 bytes] (   117035 msec)
```

## 改善版の結果 (`file@Reader.readLine`)
```
> kuincl -i main.kn -o main.exe -r -q && main.exe
Test #1 to #15
 #          Time [          Bytes] (         Total)
 1        0 msec [     1024 bytes] (        0 msec)
 2        0 msec [     2048 bytes] (        1 msec)
 3        0 msec [     4096 bytes] (        2 msec)
 4        1 msec [     8192 bytes] (        4 msec)
 5        2 msec [    16384 bytes] (        7 msec)
 6        3 msec [    32768 bytes] (       11 msec)
 7        6 msec [    65536 bytes] (       18 msec)
 8       14 msec [   131072 bytes] (       33 msec)
 9       26 msec [   262144 bytes] (       60 msec)
10       47 msec [   524288 bytes] (      110 msec)
11       96 msec [  1048576 bytes] (      208 msec)
12      190 msec [  2097152 bytes] (      399 msec)
13      370 msec [  4194304 bytes] (      771 msec)
14      724 msec [  8388608 bytes] (     1499 msec)
15     1438 msec [ 16777216 bytes] (     2940 msec)
```

# `cui@input` のテスト
これにより、標準入力から 2097152 文字受け取るのに 1487 msec かかっていたのが 197 msec で済んでいることがわかります。
(冒頭に記述したyukicoderの問題で実行時間オーバーにならずに済みます。)
## テストに使用したコード
```
func main()
	do testReadLines()
	
	func testReadLines(): []char
		do cui@print(" #          Time [          Bytes] (         Total)\n")
		var i: int :: 1
		var startTime0: int :: lib@sysTime()
		while loop(true)
			var startTime: int :: lib@sysTime()
			var input: []char :: cui@input()
			var endTime: int :: lib@sysTime()
			if(^input = 0)
				break loop
			end if
			var totalTime: int :: endTime - startTime0
			do cui@print("\{i.toStrFmt("2d")}\{(endTime - startTime).toStrFmt("9d")} msec [\{(^input).toStrFmt("9d")} bytes] (\{(endTime - startTime0).toStrFmt("9d")} msec)\n")
			do i :+ 1
		end while
	end func
end func
```

## 現行版の結果 (`cui@input`)
```
> kuincl -i main.kn -o main.exe -r -q && main.exe < ___test___.txt
 #          Time [          Bytes] (         Total)
 1        0 msec [     1024 bytes] (        0 msec)
 2        0 msec [     2048 bytes] (        1 msec)
 3        1 msec [     4096 bytes] (        3 msec)
 4        1 msec [     8192 bytes] (        5 msec)
 5        2 msec [    16384 bytes] (        8 msec)
 6        3 msec [    32768 bytes] (       12 msec)
 7        7 msec [    65536 bytes] (       20 msec)
 8       16 msec [   131072 bytes] (       36 msec)
 9       32 msec [   262144 bytes] (       71 msec)
10       94 msec [   524288 bytes] (      167 msec)
11      352 msec [  1048576 bytes] (      520 msec)
12     1487 msec [  2097152 bytes] (     2009 msec)
13     4998 msec [  4194304 bytes] (     7009 msec)
14    21271 msec [  8388608 bytes] (    28282 msec)
15    88704 msec [ 16777216 bytes] (   116988 msec)
```

## 改善版の結果 (`cui@input`)
```
> kuincl -i main.kn -o main.exe -r -q && main.exe < ___test___.txt
 #          Time [          Bytes] (         Total)
 1        0 msec [     1024 bytes] (        0 msec)
 2        0 msec [     2048 bytes] (        1 msec)
 3        1 msec [     4096 bytes] (        3 msec)
 4        1 msec [     8192 bytes] (        4 msec)
 5        1 msec [    16384 bytes] (        7 msec)
 6        4 msec [    32768 bytes] (       12 msec)
 7        6 msec [    65536 bytes] (       19 msec)
 8       14 msec [   131072 bytes] (       34 msec)
 9       28 msec [   262144 bytes] (       63 msec)
10       55 msec [   524288 bytes] (      119 msec)
11      105 msec [  1048576 bytes] (      225 msec)
12      197 msec [  2097152 bytes] (      424 msec)
13      368 msec [  4194304 bytes] (      794 msec)
14      768 msec [  8388608 bytes] (     1565 msec)
15     1621 msec [ 16777216 bytes] (     3190 msec)
```

# 補足
下記2ファイルに手を加えました。
```
\src\lib\sys\cui.kn
\src\lib\sys\file.kn
```
更に `\src\lib\converter.exe` を実行することで `\src\sys` フォルダ内の6ファイルが自動的に更新され、合計8ファイル変更しました。
`\build\sys` のファイルは更新していません。